### PR TITLE
Fix link in plugins article

### DIFF
--- a/content/_posts/minecraft/modifications/general/2024-10-18-adding-plugins.md
+++ b/content/_posts/minecraft/modifications/general/2024-10-18-adding-plugins.md
@@ -18,7 +18,7 @@ Minecraft plugins are server-side user-created modifications or additions to the
 
 ## Server Software With Plugin Support:
 
-Due to how plugins work, a special server software is needed to needed to inject and run the plugin itself, with each plugin supporting a certain server software. To learn more about server software with plugin support, please refer to the [Plugins](minecraft/java/general/server-software#plugins) section of our server software guide.
+Due to how plugins work, a special server software is needed to needed to inject and run the plugin itself, with each plugin supporting a certain server software. To learn more about server software with plugin support, please refer to the [Plugins](/minecraft/java/general/server-software#plugins) section of our server software guide.
 
 As forked server software are based on the upstream server software, all upstream plugins should work on forked server software, meaning Spigot plugins will still work when using Paper and Purpur, and the same applies to Paper plugins used with the Purpur server software.
 


### PR DESCRIPTION
The plugins article linked to “Minecraft/general…” instead of “**/**minecraft/general” causing it to redirect to https://kb.falixnodes.net/**minecraft/modifications/general/**minecraft/java/general/server-software#plugins instead of the right url